### PR TITLE
Ep/feat/application add pet

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -6,9 +6,6 @@ class ApplicationsController < ApplicationController
     @application = Application.find(params[:id])
     if params[:commit] == "Search"
       @search_pets = Pet.search(params[:pet_search])
-    elsif params[:pets] == "#{@application.pets.last}"
-      @pet_application = PetApplication.create!(pet: @search_pets, application: @applciation)
-
     end
   end
  

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -6,6 +6,9 @@ class ApplicationsController < ApplicationController
     @application = Application.find(params[:id])
     if params[:commit] == "Search"
       @search_pets = Pet.search(params[:pet_search])
+    elsif params[:pets] == "#{@application.pets.last}"
+      @pet_application = PetApplication.create!(pet: @search_pets, application: @applciation)
+
     end
   end
  
@@ -23,6 +26,17 @@ class ApplicationsController < ApplicationController
       render :new
     end
     
+  end
+
+  def edit 
+    @application = Application.find(params[:id])
+  end
+
+  def update 
+    @application = Application.find(params[:id])
+    @application.update(application_params)
+    @application.save 
+    redirect_to "/applications/#{@application.id}"
   end
 
   def application_params

--- a/app/controllers/pet_applications_controller.rb
+++ b/app/controllers/pet_applications_controller.rb
@@ -1,7 +1,7 @@
 class PetApplicationsController < ApplicationController
   def create
     PetApplication.create(pet_app_params)
-    application = Application.find(params[:application_id])
+    redirect_to "/applications/#{params[:application_id]}"
   end
 
   private

--- a/app/controllers/pet_applications_controller.rb
+++ b/app/controllers/pet_applications_controller.rb
@@ -1,0 +1,12 @@
+class PetApplicationsController < ApplicationController
+  def create
+    PetApplication.create(pet_app_params)
+    application = Application.find(params[:application_id])
+  end
+
+  private
+
+  def pet_app_params
+    params.permit(:application_id, :pet_id)
+  end
+end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,6 +1,7 @@
 class Application < ApplicationRecord
   has_many :pet_applications 
   has_many :pets, through: :pet_applications 
+  accepts_nested_attributes_for :pets 
   validates :name, presence: true
   validates :street_address, presence: true
   validates :city, presence: true

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -5,9 +5,10 @@
 <h3>Zip Code: <%= @application.zip_code %></h3>
 <h3>Application Status: <%= @application.status %></h3>
 <h3>Why do you want to adopt this pet? <%= @application.description %></h3>
-<h3>Applying For: <% @application.pets.each do |pet| %></h3>
+<h3>Applying For: 
+<% @application.pets.each do |pet| %></h3->
   <%= pet.name %>  
-<%end %>
+<% end %></h3>
 <%if @application.status == "In-Progress"%>
   <h2>Add a Pet to this Application</h2>
   <%=form_with url:"/applications/#{@application.id}", method: :get, local: true do |f|%>
@@ -20,6 +21,7 @@
 
 <%if @search_pets%>
   <%@search_pets.each do |pet|%>
-  <p><%=pet.name%></p>
-  <%end%>
-<%end%>
+    <p><%=pet.name%><%= button_to "Adopt #{pet.name}", "/applications/#{@application.id}?pets=#{pet.name}", method: :patch %></p>
+  <%end %>
+<%end %>  
+

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -21,7 +21,7 @@
 
 <%if @search_pets%>
   <%@search_pets.each do |pet|%>
-    <p><%=pet.name%><%= button_to "Adopt #{pet.name}", "/applications/#{@application.id}?pets=#{pet.name}", method: :patch %></p>
+    <p><%=pet.name%><%= button_to "Adopt #{pet.name}", "/pet_applications?application_id=#{@application.id}&pet_id=#{pet.id}", method: :post %></p>
   <%end %>
 <%end %>  
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,4 +43,7 @@ Rails.application.routes.draw do
   get '/applications/:id', to: 'applications#show'
   post '/applications/:id', to: 'applications#create'
 
+  get '/applications/:id/edit', to: 'applications#edit'
+  patch '/applications/:id', to: 'applications#update'
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,4 +46,5 @@ Rails.application.routes.draw do
   get '/applications/:id/edit', to: 'applications#edit'
   patch '/applications/:id', to: 'applications#update'
 
+  post '/pet_applications', to: 'pet_applications#create'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,6 +5,12 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+PetApplication.destroy_all
+Pet.destroy_all
+Shelter.destroy_all
+Application.destroy_all
+
+
 shelter = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
 
 pet_1 = Pet.create!(adoptable: true, age: 1, breed: 'sphynx', name: 'Lucille Bald', shelter_id: shelter.id)

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -78,5 +78,26 @@ RSpec.describe 'the applications show page' do
          expect(page).not_to have_content("Ted")
       end
     end
+
+    describe 'adding a pet to an application' do 
+      describe 'after searching for a pet by name a user can click a button to add pet to app' do 
+        it 'button adds the pet and takes user back to applciation show page where the pet is listed' do 
+          shelter = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
+          pet_1 = shelter.pets.create!(adoptable: true, age: 1, breed: 'sphynx', name: 'Lucille Bald')
+          pet_2 = shelter.pets.create!(adoptable: true, age: 2, breed: 'american shorthair', name: 'Lucky')
+          pet_3 = shelter.pets.create!(adoptable: true, age: 5, breed: 'labrador', name: 'Ted')
+          application_1 = Application.create!(name: "Taylor Swift", street_address: "22 Blank Space Ln", city: "Denver", state: "CO", zip_code: 80230, status: "In-Progress", description: "I love cats")
+          pet_app = PetApplication.create(pet: pet_1, application: application_1)
+          visit "/applications/#{application_1.id}"
+          fill_in 'pet_search', with: 'luc'
+          click_button 'Search'
+          expect(page).to have_content("Lucille Bald")
+
+          click_button "Adopt #{pet_app.pet.name}"
+          expect(page).to have_content("Applying For: Lucille Bald")
+          save_and_open_page
+        end
+      end
+    end
   end
 end 

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -87,15 +87,19 @@ RSpec.describe 'the applications show page' do
           pet_2 = shelter.pets.create!(adoptable: true, age: 2, breed: 'american shorthair', name: 'Lucky')
           pet_3 = shelter.pets.create!(adoptable: true, age: 5, breed: 'labrador', name: 'Ted')
           application_1 = Application.create!(name: "Taylor Swift", street_address: "22 Blank Space Ln", city: "Denver", state: "CO", zip_code: 80230, status: "In-Progress", description: "I love cats")
-          pet_app = PetApplication.create(pet: pet_1, application: application_1)
+
           visit "/applications/#{application_1.id}"
+
+          expect(page).not_to have_content("Applying For: Lucille Bald")
+
           fill_in 'pet_search', with: 'luc'
           click_button 'Search'
-          expect(page).to have_content("Lucille Bald")
 
-          click_button "Adopt #{pet_app.pet.name}"
+          expect(page).to have_content("Lucille Bald")
+          
+          click_button "Adopt #{pet_1.name}"
+          
           expect(page).to have_content("Applying For: Lucille Bald")
-          save_and_open_page
         end
       end
     end


### PR DESCRIPTION
Added the ability to add pets to an application by creating a pet_application record to link the two. When searching for pets on an unsubmitted application, each pet has a button to apply to adopt that pet. On clicking the button, a pet_application is created with the chosen pet's ID and the application ID. The user will be redirected to the show page where they can see the names of the pets they're applying for. Added the PetApplications controller to handle the creation of pet_application records.